### PR TITLE
Add README and CI baseline for vite-skeleton

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    groups:
+      npm-patch-minor:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  php:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+      - run: composer validate --no-check-publish
+      - run: composer install --prefer-dist --no-interaction --no-progress
+
+  node:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# contributte/vite-skeleton
+
+## Goal and stack
+
+Minimal production-ready starter for Nette applications with Vite asset bundling.
+
+- PHP 8.4+
+- Nette Framework 3.2+
+- Node.js and npm for frontend tooling
+
+## Requirements
+
+- PHP 8.4 or newer
+- Node.js 20+ and npm 10+
+
+## Installation
+
+```bash
+composer install
+npm ci
+```
+
+## Development commands
+
+```bash
+npm run dev
+php -S 127.0.0.1:8000 -t www
+```
+
+## Build commands
+
+```bash
+npm run build
+npm run preview
+```
+
+## Writable directories
+
+Application runtime directories must be writable by the web server/PHP process:
+
+- `temp/`
+- `log/`
+
+Prefer correct ownership and group permissions (for example `775`) over world-writable permissions.


### PR DESCRIPTION
## Summary
- add a README with stack, requirements, installation, and developer commands
- add CI workflow for PHP composer validation and Node build checks
- add Dependabot configuration for composer and npm with PR limits and npm grouping

## Why
- vite-skeleton currently lacks onboarding docs and CI checks
- this establishes a minimum baseline to reduce setup friction and catch regressions earlier